### PR TITLE
Update eidas-metadata-servicelist-1.0.xsd

### DIFF
--- a/docs/eidas/1.0/eidas-metadata-servicelist-1.0.xsd
+++ b/docs/eidas/1.0/eidas-metadata-servicelist-1.0.xsd
@@ -108,7 +108,7 @@
           </xs:documentation>
         </xs:annotation>
       </xs:element>
-      <xs:element ref="ds:KeyInfo" minOccurs="0">
+      <xs:element ref="ds:KeyInfo" minOccurs="0" maxOccurs="unbounded">
         <xs:annotation>
           <xs:documentation>
             Key material (usually a certificate) that should be used to verify the signature


### PR DESCRIPTION
Fixes the reported bug in MDSL where only one metadata verification key was possible in the schema.